### PR TITLE
feat(location): Allow filtering by location

### DIFF
--- a/db/migrations/20190403155025_create_location.js
+++ b/db/migrations/20190403155025_create_location.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.up = async (Knex) => {
+  await Knex.schema.createTable('locations', (table) => {
+    table.integer('movie_id').notNullable();
+    table.text('location').notNullable();
+  });
+};
+
+exports.down = async (Knex) => {
+  await Knex.schema.dropTable('locations');
+};

--- a/db/migrations/20190404124757_create_location_index.js
+++ b/db/migrations/20190404124757_create_location_index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const INDEX_NAME = 'location_movie_id_unique_idx';
+
+exports.up = async (Knex) => {
+  await Knex.raw(`
+    CREATE UNIQUE INDEX CONCURRENTLY ${INDEX_NAME} ON  locations (movie_id,location)
+  `);
+};
+
+exports.down = async (Knex) => {
+  await Knex.raw(`
+      DROP INDEX CONCURRENTLY ${INDEX_NAME}
+    `);
+};
+
+exports.config = {
+  transaction: false
+};

--- a/db/seeds/data/locations.json
+++ b/db/seeds/data/locations.json
@@ -1,0 +1,14 @@
+[
+  {
+    "movie_id": 1,
+    "location": "San Francisco"
+  },
+  {
+    "movie_id": 1,
+    "location": "Palo Alto"
+  },
+  {
+    "movie_id": 2,
+    "location": "San Francisco"
+  }
+]

--- a/db/seeds/index.js
+++ b/db/seeds/index.js
@@ -1,8 +1,11 @@
 'use strict';
 
-const Movies = require('./data/movies');
+const Movies    = require('./data/movies');
+const Locations = require('./data/locations');
 
 exports.seed = async (Knex) => {
   await Knex('movies').truncate();
   await Knex('movies').insert(Movies);
+  await Knex('locations').truncate();
+  await Knex('locations').insert(Locations);
 };

--- a/lib/models/location.js
+++ b/lib/models/location.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+
+module.exports = Bookshelf.Model.extend({
+  idAttribute: null,
+  tableName: 'locations',
+  serialize: function () {
+    return {
+      movie_id: this.get('movie_id'),
+      location: this.get('location')
+    };
+  }
+});

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -1,15 +1,20 @@
 'use strict';
 
 const Bookshelf = require('../libraries/bookshelf');
+const Location  = require('./location');
 
 module.exports = Bookshelf.Model.extend({
   tableName: 'movies',
+  locations: function () {
+    return this.hasMany(Location);
+  },
   serialize: function () {
     return {
       id: this.get('id'),
       title: this.get('title'),
       release_year: this.get('release_year'),
-      object: 'movie'
+      object: 'movie',
+      locations: this.related('locations').map((location) => location.serialize().location)
     };
   }
 });

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,18 +1,31 @@
 'use strict';
 
-const Movie = require('../../../models/movie');
+const Movie    = require('../../../models/movie');
+const Location = require('../../../models/location');
+const Knex     = require('../../../libraries/knex');
 
 exports.create = async (payload) => {
   const movie = await new Movie().save(payload);
 
-  return new Movie({ id: movie.id }).fetch();
+  return new Movie({ id: movie.id }).fetch({ withRelated: ['locations'] });
+};
+
+exports.associateLocation = async (params, payload) => {
+
+  const moviePayload = { ...payload, ...params };
+
+  await new Location().save(moviePayload);
+
+  return new Movie({ id: params.movie_id }).fetch({ withRelated: ['locations'] });
+
 };
 
 exports.findAll = async (query = {}) => {
-  let title = query.title; //string with or without %, % triggers fuzzy search
-  const { release_year, start_year, end_year } = query; //(start_year and/or end_year), OR release_year
+  let { title } = query; //string with or without %, % triggers fuzzy search
+  const { location, release_year, start_year, end_year } = query; //(start_year and/or end_year), OR release_year
 
   return new Movie().query((qb) => {
+
     if (title) {
       title = title.toLowerCase();
       if (title.indexOf('%') > -1) {
@@ -34,5 +47,14 @@ exports.findAll = async (query = {}) => {
         qb.where('release_year', '<=', parseInt(end_year));
       }
     }
-  }).fetchAll();
+
+    if (location) { //Bookshelf: https://github.com/bookshelf/bookshelf/issues/834
+      qb.leftJoin('locations', 'movies.id', 'locations.movie_id');
+      qb.select('movies.*');
+      qb.select(Knex.raw('array_agg(location) as locations'));
+      qb.groupBy('movies.id');
+      qb.whereIn('location', [location]);
+    }
+
+  }).fetchAll({ withRelated: 'locations' });
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,31 +1,43 @@
 'use strict';
 
-const MovieValidator = require('../../../validators/movie');
-const Controller     = require('./controller');
+const MovieValidator    = require('../../../validators/movie');
+const LocationValidator = require('../../../validators/location');
+const Controller        = require('./controller');
 
 exports.register = (server, options, next) => {
 
-  server.route([{
-    method: 'POST',
-    path: '/movies',
-    config: {
-      handler: (request, reply) => {
-        reply(Controller.create(request.payload));
-      },
-      validate: {
-        payload: MovieValidator
+  server.route([
+    {
+      method: 'POST',
+      path: '/movies/{movie_id}/locations',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.associateLocation(request.params, request.payload));
+        },
+        validate: LocationValidator
       }
-    }
-  },
-  {
-    method: 'GET',
-    path: '/movies',
-    config: {
-      handler: (request, reply) => {
-        reply(Controller.findAll(request.query));
+    },
+    {
+      method: 'POST',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.create(request.payload));
+        },
+        validate: {
+          payload: MovieValidator
+        }
       }
-    }
-  }]);
+    },
+    {
+      method: 'GET',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.findAll(request.query));
+        }
+      }
+    }]);
 
   next();
 

--- a/lib/validators/location.js
+++ b/lib/validators/location.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = {
+  payload: { location: Joi.string().min(1).required() },
+  params: { movie_id: Joi.number().integer().min(1).required() }
+};

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -13,6 +13,7 @@ describe('movie model', () => {
         'id',
         'title',
         'release_year',
+        'locations',
         'object'
       ]);
     });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -14,6 +14,17 @@ describe('movie controller', () => {
 
   });
 
+  describe('associates a location to a movie', () => {
+
+    it('creates a movie and associates a location', async () => {
+      const payload = { title: 'TestLocationMovies!' };
+      const movie = await Controller.create(payload);
+      const movieWithLocation = await Controller.associateLocation({ movie_id: movie.id }, { location: 'San Francisco' });
+      expect(movieWithLocation.serialize().locations).to.include('San Francisco');
+    });
+
+  });
+
   describe('get', () => {
 
     it('returns a list of movies if no query params are passed', async () => {
@@ -65,6 +76,13 @@ describe('movie controller', () => {
       expect(movies.models['0'].attributes.title).to.eql('Barbary Coast');
       expect(movies.models['1'].attributes.title).to.eql('The Jazz Singer');
       expect(movies.models.length).to.equal(2);
+    });
+
+    it('returns a list of movies with a location', async () => {
+      const movies = await Controller.findAll({ location: 'San Francisco' });
+      expect(movies.models['0'].attributes.title).to.eql('180');
+      expect(movies.models['1'].attributes.title).to.eql('24 Hours on Craigslist');
+      expect(movies.models.length).to.equal(3);
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -23,6 +23,36 @@ describe('movies integration', () => {
 
   });
 
+  describe('location', () => {
+
+    it('associates a location', async () => {
+      const payload = { location: 'Berkeley' };
+
+      const response = await Movies.inject({
+        url: '/movies/1/locations',
+        method: 'POST',
+        payload
+      });
+
+      expect(response.statusCode).to.eql(200);
+      expect(response.result.object).to.eql('movie');
+      expect(response.result.locations).to.include.members(['Berkeley']);
+    });
+
+    it('does not associate a location multiple times', async () => {
+      const payload = { location: 'Berkeley' };
+
+      const response = await Movies.inject({
+        url: '/movies/1/locations',
+        method: 'POST',
+        payload
+      });
+
+      expect(response.statusCode).to.eql(500);
+    });
+
+  });
+
   describe('get', () => {
 
     it('gets a list of movies', async () => {
@@ -46,7 +76,18 @@ describe('movies integration', () => {
       expect(response.statusCode).to.eql(200);
       expect(response.result['0'].title).to.eql('180');
       expect(response.result.length).to.equal(1);
+    });
 
+    it('gets a movie with a location', async () => {
+      const response = await Movies.inject({
+        url: '/movies?location=San%20Francisco',
+        method: 'GET'
+      });
+
+      expect(response.statusCode).to.eql(200);
+      expect(response.result['0'].title).to.eql('180');
+      expect(response.result['1'].title).to.eql('24 Hours on Craigslist');
+      expect(response.result.length).to.equal(3);
     });
 
     it('supports fuzzy titles', async () => {
@@ -126,7 +167,6 @@ describe('movies integration', () => {
       expect(response.statusCode).to.eql(200);
       expect(response.result['0'].title).to.eql('A Jitney Elopement');
       expect(response.result.length).to.equal(1);
-
     });
 
   });

--- a/test/validators/location.test.js
+++ b/test/validators/location.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const Joi = require('joi');
+
+const LocationValidator = require('../../lib/validators/location');
+
+describe('location validator', () => {
+
+  describe('movie_id', () => {
+
+    it('is required', () => {
+      const payload = { location: 'Test' };
+      const params = {};
+      const request = { payload, params };
+      const result = Joi.validate(request, LocationValidator);
+      expect(result.error.details[0].path[1]).to.eql('movie_id');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is greater than or equal to 1', () => {
+
+      const payload = { location: 'Test' };
+      const params = { movie_id: 0 };
+      const request = { payload, params };
+
+      const result = Joi.validate(request, LocationValidator);
+      expect(result.error.details[0].path[1]).to.eql('movie_id');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+  });
+
+  describe('location', () => {
+
+    it('is required', () => {
+      const payload = { };
+      const params = { movie_id: 1 };
+      const request = { payload, params };
+
+      const result = Joi.validate(request, LocationValidator);
+      expect(result.error.details[0].path[1]).to.eql('location');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is greater than 1 characters', () => {
+      const payload = { location: '' };
+      const params = { movie_id: 1 };
+      const request = { payload, params };
+
+      const result = Joi.validate(request, LocationValidator);
+      expect(result.error.details[0].path[1]).to.eql('location');
+      expect(result.error.details[0].type).to.eql('any.empty');
+    });
+
+  });
+
+});


### PR DESCRIPTION
**What**

https://lobsters.atlassian.net/browse/ENG-10572

- [x] migration  to make the location association possible
- [x] return array of locations in GET /movies
- [x] add POST /movies/{id}/locations to add new locations to a movie
- [x] be able to pass in any combination of filters

**Why**
To be able to demonstrate ability with migration and association.

**Interesting**
I do not know how to query bookshelf withRelated in the query without doing multiple queries to the DB. It felt wrong to do multiple queries so I instead did a manual inner join on the necessary data to do the call in one go. Documentation from bookshelf and forums shows this to be a limitation:
//Bookshelf: https://github.com/bookshelf/bookshelf/issues/834

`    if (location) { 
         qb.leftJoin('locations', 'movies.id', 'locations.movie_id');
         qb.select('movies.*');
         qb.select(Knex.raw('array_agg(location) as locations'));
         qb.groupBy('movies.id');
         qb.whereIn('location', [location]);
    }
`